### PR TITLE
doc: Update manual setup description

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ Once dependencies are installed, clone this repo and run ``setup.py``:
 
    $ git clone https://github.com/getpatchwork/pwclient
    $ cd pwclient
-   $ sudo python setup.py
+   $ sudo python setup.py install
 
 Getting Started
 ---------------


### PR DESCRIPTION
Running only setup.py file gives below usage description:
>> usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
   >> or: setup.py --help [cmd1 cmd2 ...]
   >> or: setup.py --help-commands
   >> or: setup.py cmd --help

>> error: no commands supplied

So give install as an additional parameter to setup.py